### PR TITLE
fixed#4: moving builds to top does not alter build name

### DIFF
--- a/src/main/webapp/buildReOrdering.js
+++ b/src/main/webapp/buildReOrdering.js
@@ -44,7 +44,7 @@ YUI().use('node', 'io', 'xbdd', 'statusHelpers', 'handlebars', 'build-reordering
 							i;
 
 						for (i = 0; i < builds.size(); i++) {
-							buildArray.push(builds.item(i).get('text').trim());
+							buildArray.push(builds.item(i).one('.title').get('text').trim());
 						}
 
 						Y.io(contextPath + 'rest/build-reorder/' + product + '/' + version, {


### PR DESCRIPTION
On firefox (possibly some other browsers) moving builds to top and bottom appends to the build name.
This pull request fixes this issue.