### PR TITLE
FIX #24: MongoDB error appears during tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,7 @@
 						</goals>
 						<configuration>
 							<port>${mongo.port}</port>
+                            <version>2.4.0</version>
 						</configuration>
 					</execution>
 					<execution>


### PR DESCRIPTION
Forced the embed mongo instance to use a more up to date version of mongodb that supports the $setOnInsert modifier