### PR TITLE
Added config for dependabot.

### DIFF
--- a/frontend/.dependabot/config.yml
+++ b/frontend/.dependabot/config.yml
@@ -1,0 +1,14 @@
+version: 1
+update_configs:
+  - package_manager: "javascript"
+    directory: "/frontend"
+    update_schedule: "daily"
+    target_branch: "feature/react-frontend"
+  - package_manager: "java:maven"
+    directory: "/frontend"
+    update_schedule: "weekly"
+    target_branch: "feature/react-frontend"
+  - package_manager: "java:maven"
+    directory: "/backend"
+    update_schedule: "weekly"
+    target_branch: "feature/react-frontend"


### PR DESCRIPTION
Looks like we only need to case about frontend and backend for mvn as the others dont have dependencies.