### PR TITLE
Feature/navigate to different build from execution history

### DIFF
--- a/frontend/src/modules/report/FeatureListContainer/FeatureListContainer.tsx
+++ b/frontend/src/modules/report/FeatureListContainer/FeatureListContainer.tsx
@@ -73,6 +73,14 @@ class FeatureListContainer extends Component<Props, State> {
     dispatchFetchTagsMetadata(productId, versionString, build);
   }
 
+  componentDidUpdate(prevProps: Props): void {
+    const { productId, versionString, build, dispatchFetchIndexes, dispatchFetchTagsMetadata } = this.props;
+    if (prevProps.productId !== productId || prevProps.versionString !== versionString || prevProps.build !== build) {
+      dispatchFetchIndexes(productId, versionString, build);
+      dispatchFetchTagsMetadata(productId, versionString, build);
+    }
+  }
+
   handleViewSwitch = (): void => {
     this.setState(prevState => ({ ...prevState, isTagView: !prevState.isTagView }));
   };

--- a/frontend/src/modules/report/FeatureSummary/ExecutionHistory.tsx
+++ b/frontend/src/modules/report/FeatureSummary/ExecutionHistory.tsx
@@ -1,4 +1,5 @@
 import React, { FC, ReactNode } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
 import { Tooltip, Typography, IconButton } from '@material-ui/core';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faCheckCircle, faExclamationCircle, faQuestionCircle, faMinusCircle } from '@fortawesome/free-solid-svg-icons';
@@ -7,17 +8,36 @@ import { withStyles, WithStyles } from '@material-ui/core/styles';
 import { executionHistoryStyles } from './styles/FeatureSummaryStyles';
 import Execution from 'models/Execution';
 import { StatusMap, Passed, Failed, Skipped, Undefined } from 'models/Status';
+import { useHistory } from 'react-router-dom';
+import { resetFeatureState } from 'redux/FeatureReducer';
+import { RootStore } from 'rootReducer';
 
 interface Props extends WithStyles {
   executionHistory: Execution[];
 }
 
 const ExecutionHistory: FC<Props> = ({ executionHistory, classes }) => {
+  const history = useHistory();
+  const dispatch = useDispatch();
+
+  const report = useSelector((state: RootStore) => state.report);
+
   const iconMap: StatusMap<ReactNode> = {
     [Passed]: <FontAwesomeIcon icon={faCheckCircle} className={classes.featurePassed} />,
     [Failed]: <FontAwesomeIcon icon={faExclamationCircle} className={classes.featureFailed} />,
     [Undefined]: <FontAwesomeIcon icon={faQuestionCircle} className={classes.featureUndefined} />,
     [Skipped]: <FontAwesomeIcon icon={faMinusCircle} className={classes.featureSkipped} />,
+  };
+
+  const navigateToBuild = (build: string) => {
+    if (report.build === build) {
+      return;
+    }
+    const productParam = encodeURIComponent(report.product);
+    const versionParam = encodeURIComponent(report.version);
+    const buildParam = encodeURIComponent(build);
+    dispatch(resetFeatureState());
+    history.push(encodeURI(`/reports/${productParam}/${versionParam}/${buildParam}`));
   };
 
   return (
@@ -26,7 +46,9 @@ const ExecutionHistory: FC<Props> = ({ executionHistory, classes }) => {
       {executionHistory.map(build => (
         <span key={build.build}>
           <Tooltip title={build.build} placement="top">
-            <IconButton className={classes.executionHistoryIcon}>{iconMap[build.calculatedStatus]}</IconButton>
+            <IconButton className={classes.executionHistoryIcon} onClick={() => navigateToBuild(build.build)}>
+              {iconMap[build.calculatedStatus]}
+            </IconButton>
           </Tooltip>
         </span>
       ))}

--- a/frontend/src/modules/report/ReportContainer.tsx
+++ b/frontend/src/modules/report/ReportContainer.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react';
+import React, { FC, useEffect } from 'react';
 import { Grid, Card } from '@material-ui/core';
 import { withStyles, WithStyles } from '@material-ui/core/styles';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
 
 import { reportContainerStyles } from './styles/ReportContainerStyles';
 import FeatureListContainer from './FeatureListContainer/FeatureListContainer';
@@ -9,6 +9,7 @@ import ScenarioDisplay from './ScenarioDisplay/ScenarioDisplay';
 import FeatureSummary from './FeatureSummary/FeatureSummary';
 import { LoggedInUser } from 'models/User';
 import { RootStore } from 'rootReducer';
+import { updateReportIdentifier } from 'redux/ReportReducer';
 
 interface Props extends WithStyles {
   user: LoggedInUser;
@@ -20,6 +21,11 @@ interface Props extends WithStyles {
 const ReportContainer: FC<Props> = ({ user, productId, versionString, build, classes }) => {
   const selectedFeature = useSelector((state: RootStore) => state.feature.selected);
   const executionHistory = useSelector((state: RootStore) => state.feature.executionHistory);
+
+  const dispatch = useDispatch();
+  useEffect(() => {
+    dispatch(updateReportIdentifier(productId, versionString, build));
+  });
 
   if (!user) {
     return null;

--- a/frontend/src/redux/ReportReducer.ts
+++ b/frontend/src/redux/ReportReducer.ts
@@ -1,0 +1,46 @@
+import { createSlice, PayloadAction, CaseReducer } from '@reduxjs/toolkit';
+import { StoreDispatch } from 'rootReducer';
+
+interface Report {
+  product: string;
+  version: string;
+  build: string;
+}
+
+type ReportState = Report;
+
+type UpdateReportAction = PayloadAction<Report>;
+
+const updateReportReducer: CaseReducer<ReportState, UpdateReportAction> = (state, action) => {
+  state.product = action.payload.product;
+  state.version = action.payload.version;
+  state.build = action.payload.build;
+  return state;
+};
+
+const initialState: ReportState = {
+  product: '',
+  version: '',
+  build: '',
+};
+
+const resetReportStateReducer: CaseReducer = () => {
+  return initialState;
+};
+
+const { actions, reducer } = createSlice({
+  name: 'Report',
+  initialState,
+  reducers: {
+    updateReport: updateReportReducer,
+    resetReport: resetReportStateReducer,
+  },
+});
+
+export const { updateReport, resetReport } = actions;
+
+export const updateReportIdentifier = (product: string, version: string, build: string) => (dispatch: StoreDispatch): void => {
+  dispatch(updateReport({ product, version, build }));
+};
+
+export default reducer;

--- a/frontend/src/rootReducer.ts
+++ b/frontend/src/rootReducer.ts
@@ -1,11 +1,13 @@
 import { combineReducers } from 'redux';
 import { configureStore } from '@reduxjs/toolkit';
 
+import reportReducer from 'redux/ReportReducer';
 import featureReducer from 'redux/FeatureReducer';
 import tagsMetadataReducer from 'redux/TagsMetadataReducer';
 import userReducer from './redux/UserReducer';
 
 const rootReducer = combineReducers({
+  report: reportReducer,
   feature: featureReducer,
   tags: tagsMetadataReducer,
   user: userReducer,


### PR DESCRIPTION
Add the report reducer and store the report identifier in the redux state so that the execution history can know the product, version. The other way to go is pass it down with props, but keep it in the state could be useful for future feature.
Issue: https://github.com/orionhealth/XBDD/issues/167